### PR TITLE
compatibility with PHPUnit 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": ">=5.4",
-        "phpunit/phpunit": "^4.5 || ^5.0",
+        "phpunit/phpunit": "^4.8.35 || ^5.4.3 || ^6.0",
         "php-http/httplug": "^1.0",
         "php-http/message": "^1.0",
         "guzzlehttp/psr7": "^1.0",

--- a/src/HttpBaseTest.php
+++ b/src/HttpBaseTest.php
@@ -5,9 +5,10 @@ namespace Http\Client\Tests;
 use Http\Message\MessageFactory;
 use Http\Message\MessageFactory\GuzzleMessageFactory;
 use Nerd\CartesianProduct\CartesianProduct;
+use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 
-abstract class HttpBaseTest extends \PHPUnit_Framework_TestCase
+abstract class HttpBaseTest extends TestCase
 {
     /**
      * @var string

--- a/src/HttpFeatureTest.php
+++ b/src/HttpFeatureTest.php
@@ -5,8 +5,9 @@ namespace Http\Client\Tests;
 use Http\Client\HttpClient;
 use Http\Message\MessageFactory;
 use Http\Message\MessageFactory\GuzzleMessageFactory;
+use PHPUnit\Framework\TestCase;
 
-abstract class HttpFeatureTest extends \PHPUnit_Framework_TestCase
+abstract class HttpFeatureTest extends TestCase
 {
     /**
      * @var MessageFactory


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | yes (dropped support for PHPUnit versions that do not have the FC layer for namespaced PHPUnit classes)
| Deprecations?   | no
| Related tickets | 
| Documentation   | 
| License         | MIT


#### What's in this PR?

Makes the package compatible with all PHPUnit versions that support the namespaced test case class.


#### Why?

In PHPUnit 6, the `PHPUnit_Framework_TestCase` class no longer exists (you have to use `TestCase` class from the `PHPUnit\Framework` namespace instead).


#### Example Usage

n/a


#### Checklist

- [ ] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [ ] ~~Documentation pull request created (if not simply a bugfix)~~
- [ ] update `FeatureTestListener`


#### To Do

- [ ] update changelog
