### PR TITLE
Don't make any TRACE requests with a request body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ## UNRELEASED
 
+- Don't test `TRACE` requests with request bodies, as they're not valid requests according to the [RFC](https://tools.ietf.org/html/rfc7231#section-4.3.8).
+
 ### Changed
 
 - Make the test suite PHPUnit 6 compatible

--- a/src/HttpBaseTest.php
+++ b/src/HttpBaseTest.php
@@ -73,7 +73,16 @@ abstract class HttpBaseTest extends TestCase
 
         $cartesianProduct = new CartesianProduct($sets);
 
-        return $cartesianProduct->compute();
+        $cases = $cartesianProduct->compute();
+
+        // Filter all TRACE requests with a body, as they're not HTTP spec compliant
+        return array_filter($cases, function ($case) {
+            if ($case[0] === 'TRACE' && $case[3] !== null) {
+                return false;
+            }
+
+            return true;
+        });
     }
 
     /**
@@ -262,7 +271,7 @@ abstract class HttpBaseTest extends TestCase
             $name = strtoupper(str_replace('-', '_', 'http-'.$name));
 
             $this->assertArrayHasKey($name, $request['SERVER']);
-            $this->assertSame($value, $request['SERVER'][$name]);
+            $this->assertSame($value, $request['SERVER'][$name], "Failed asserting value for {$name}.");
         }
     }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | Fixes #28.
| License         | MIT

#### What's in this PR?

https://tools.ietf.org/html/rfc7231#section-4.3.8 defines that TRACE requests MUST NOT have a request body.

- [x] Updated CHANGELOG.md to describe the bugfix.