### PR TITLE
Add artax-adapter to tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ cache:
         - $HOME/.composer/cache/files
 
 php:
-    5.5
+    - 5.5
 
 env:
     - SUITE="curl" PACKAGE="php-http/curl-client:dev-master zendframework/zend-diactoros"
@@ -20,6 +20,9 @@ env:
     - SUITE="Zend" PACKAGE="php-http/buzz-adapter:dev-master"
 
 matrix:
+    include:
+        - php: 7.0
+          env: SUITE="Artax" PACKAGE="php-http/artax-adapter:dev-master"
     allow_failures:
         - env: SUITE="Socket" PACKAGE="php-http/socket-client:dev-master php-http/client-common"
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit colors="true" bootstrap="vendor/autoload.php">
     <testsuites>
+        <testsuite name="Artax">
+            <directory>vendor/php-http/artax-adapter/tests</directory>
+        </testsuite>
         <testsuite name="curl">
             <directory>vendor/php-http/curl-client/tests</directory>
         </testsuite>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | Replaces #30.
| License         | MIT

#### What's in this PR?

Adds Artax to tests. Artax is PHP 7.0+, so execute its test on 7.0.