### PR TITLE
Sending Content-Length: 0 is optional for TRACE

### DIFF
--- a/src/HttpBaseTest.php
+++ b/src/HttpBaseTest.php
@@ -270,6 +270,10 @@ abstract class HttpBaseTest extends TestCase
 
             $name = strtoupper(str_replace('-', '_', 'http-'.$name));
 
+            if ($method === 'TRACE' && $name === 'HTTP_CONTENT_LENGTH' && !isset($request['SERVER'][$name])) {
+                $request['SERVER'][$name] = '0';
+            }
+
             $this->assertArrayHasKey($name, $request['SERVER']);
             $this->assertSame($value, $request['SERVER'][$name], "Failed asserting value for {$name}.");
         }

--- a/src/HttpBaseTest.php
+++ b/src/HttpBaseTest.php
@@ -271,7 +271,7 @@ abstract class HttpBaseTest extends TestCase
             $name = strtoupper(str_replace('-', '_', 'http-'.$name));
 
             if ($method === 'TRACE' && $name === 'HTTP_CONTENT_LENGTH' && !isset($request['SERVER'][$name])) {
-                $request['SERVER'][$name] = '0';
+                continue;
             }
 
             $this->assertArrayHasKey($name, $request['SERVER']);


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | Fixes #18, #28.
| License         | MIT

#### What's in this PR?

As no body is allowed, the `content-length` header is optional.