### PR TITLE
Use __toString instead of getContents

### DIFF
--- a/src/HttpBaseTest.php
+++ b/src/HttpBaseTest.php
@@ -234,9 +234,9 @@ abstract class HttpBaseTest extends TestCase
         }
 
         if (null === $options['body']) {
-            $this->assertEmpty($response->getBody()->getContents());
+            $this->assertEmpty($response->getBody()->__toString());
         } else {
-            $this->assertContains($options['body'], $response->getBody()->getContents());
+            $this->assertContains($options['body'], $response->getBody()->__toString());
         }
     }
 

--- a/src/HttpFeatureTest.php
+++ b/src/HttpFeatureTest.php
@@ -61,7 +61,7 @@ abstract class HttpFeatureTest extends TestCase
         $this->assertInstanceOf('Psr\Http\Message\ResponseInterface', $response);
         $this->assertSame(200, $response->getStatusCode());
 
-        $contents = json_decode($response->getBody()->getContents());
+        $contents = json_decode($response->getBody()->__toString());
 
         $this->assertEquals($testData, $contents->data);
     }
@@ -132,7 +132,7 @@ abstract class HttpFeatureTest extends TestCase
         $this->assertInstanceOf('Psr\Http\Message\ResponseInterface', $response);
         $this->assertSame(200, $response->getStatusCode());
 
-        $contents = json_decode($response->getBody()->getContents());
+        $contents = json_decode($response->getBody()->__toString());
 
         $this->assertEquals($testData, $contents->data);
     }
@@ -151,7 +151,7 @@ abstract class HttpFeatureTest extends TestCase
 
         $this->assertInstanceOf('Psr\Http\Message\ResponseInterface', $response);
         $this->assertSame(200, $response->getStatusCode());
-        $this->assertContains('€', $response->getBody()->getContents());
+        $this->assertContains('€', $response->getBody()->__toString());
     }
 
     /**
@@ -168,7 +168,7 @@ abstract class HttpFeatureTest extends TestCase
 
         $this->assertInstanceOf('Psr\Http\Message\ResponseInterface', $response);
         $this->assertSame(200, $response->getStatusCode());
-        $this->assertContains('gzip', $response->getBody()->getContents());
+        $this->assertContains('gzip', $response->getBody()->__toString());
     }
 
     /**
@@ -185,7 +185,7 @@ abstract class HttpFeatureTest extends TestCase
 
         $this->assertInstanceOf('Psr\Http\Message\ResponseInterface', $response);
         $this->assertSame(200, $response->getStatusCode());
-        $this->assertContains('deflate', $response->getBody()->getContents());
+        $this->assertContains('deflate', $response->getBody()->__toString());
     }
 
     /**
@@ -219,7 +219,7 @@ abstract class HttpFeatureTest extends TestCase
         $this->assertInstanceOf('Psr\Http\Message\ResponseInterface', $response);
         $this->assertSame(200, $response->getStatusCode());
 
-        $content = @json_decode($response->getBody()->getContents());
+        $content = @json_decode($response->getBody()->__toString());
 
         $this->assertNotNull($content);
     }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| Documentation   | 
| License         | MIT


#### What's in this PR?

__toString will always give the full body. 