### PR TITLE
3.x preparation : Make httplug optional, depends on psr18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [Unreleased]
+## [3.0.0] - Unreleased
+
+- Only support httplug 2.0 and psr18
+- Httplug 2.0 is now optional (only require it if you need to test async)
+- HttpClientTest now rely only on PSR18 (no need for httplug)
 
 ## [2.0.1] - 2018-12-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.0.0] - Unreleased
 
-- Only support httplug 2.0 and psr18
-- Httplug 2.0 is now optional (only require it if you need to test async)
-- HttpClientTest now rely only on PSR18 (no need for httplug)
+- Only support HTTPlug 2.0 and PSR-18
+- HTTPlug 2.0 is now optional (only require it if you need to test async)
+- HttpClientTest now relies only on PSR-18 (no need for HTTPlug)
 
 ## [2.0.1] - 2018-12-27
 

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
     ],
     "extra": {
         "branch-alias": {
-            "dev-master": "2.x-dev"
+            "dev-master": "3.x-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -15,12 +15,17 @@
         }
     ],
     "require": {
-        "php": ">=5.4",
-        "phpunit/phpunit": "^4.8.35 || ^5.4.3 || ^6.0 || ^7.0",
-        "php-http/httplug": "^1.0 || ^2.0",
+        "php": ">=7.1",
+        "phpunit/phpunit": "^7.0",
         "php-http/message": "^1.0",
         "guzzlehttp/psr7": "^1.0",
         "th3n3rd/cartesian-product": "^0.3"
+    },
+    "suggest": {
+        "php-http/httplug": "To test async client"
+    },
+    "require-dev": {
+        "php-http/httplug": "^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": ">=7.1",
+        "php": "^7.1",
         "phpunit/phpunit": "^7.0",
         "php-http/message": "^1.0",
         "guzzlehttp/psr7": "^1.0",

--- a/src/HttpAsyncClientTest.php
+++ b/src/HttpAsyncClientTest.php
@@ -27,10 +27,7 @@ abstract class HttpAsyncClientTest extends HttpBaseTest
         unset($this->httpAdapter);
     }
 
-    /**
-     * @return HttpAsyncClient
-     */
-    abstract protected function createHttpAsyncClient();
+    abstract protected function createHttpAsyncClient(): HttpAsyncClient;
 
     public function testSuccessiveCallMustUseResponseInterface()
     {

--- a/src/HttpBaseTest.php
+++ b/src/HttpBaseTest.php
@@ -59,10 +59,7 @@ abstract class HttpBaseTest extends TestCase
         }
     }
 
-    /**
-     * @return array
-     */
-    public function requestProvider()
+    public function requestProvider(): array
     {
         $sets = [
             'methods' => $this->getMethods(),
@@ -85,10 +82,7 @@ abstract class HttpBaseTest extends TestCase
         });
     }
 
-    /**
-     * @return array
-     */
-    public function requestWithOutcomeProvider()
+    public function requestWithOutcomeProvider(): array
     {
         $sets = [
             'urisAndOutcomes' => $this->getUrisAndOutcomes(),
@@ -102,10 +96,7 @@ abstract class HttpBaseTest extends TestCase
         return $cartesianProduct->compute();
     }
 
-    /**
-     * @return array
-     */
-    private function getMethods()
+    private function getMethods(): array
     {
         return [
             'GET',
@@ -211,14 +202,8 @@ abstract class HttpBaseTest extends TestCase
         return ['param1' => 'foo', 'param2' => ['bar', ['baz']]];
     }
 
-    /**
-     * @param ResponseInterface $response
-     * @param array             $options
-     */
-    protected function assertResponse($response, array $options = [])
+    protected function assertResponse(ResponseInterface $response, array $options = [])
     {
-        $this->assertInstanceOf('Psr\Http\Message\ResponseInterface', $response);
-
         $options = array_merge($this->defaultOptions, $options);
 
         // The response version may be greater or equal to the request version. See https://tools.ietf.org/html/rfc2145#section-2.3

--- a/src/HttpClientTest.php
+++ b/src/HttpClientTest.php
@@ -2,7 +2,7 @@
 
 namespace Http\Client\Tests;
 
-use Http\Client\HttpClient;
+use Psr\Http\Client\ClientInterface;
 
 /**
  * @author GeLo <geloen.eric@gmail.com>
@@ -10,7 +10,7 @@ use Http\Client\HttpClient;
 abstract class HttpClientTest extends HttpBaseTest
 {
     /**
-     * @var HttpClient
+     * @var ClientInterface
      */
     protected $httpAdapter;
 
@@ -30,10 +30,7 @@ abstract class HttpClientTest extends HttpBaseTest
         unset($this->httpAdapter);
     }
 
-    /**
-     * @return HttpClient
-     */
-    abstract protected function createHttpAdapter();
+    abstract protected function createHttpAdapter(): ClientInterface;
 
     /**
      * @dataProvider requestProvider

--- a/src/HttpFeatureTest.php
+++ b/src/HttpFeatureTest.php
@@ -2,7 +2,7 @@
 
 namespace Http\Client\Tests;
 
-use Http\Client\HttpClient;
+use Psr\Http\Client\ClientInterface;
 use Http\Message\MessageFactory;
 use Http\Message\MessageFactory\GuzzleMessageFactory;
 use PHPUnit\Framework\TestCase;
@@ -22,10 +22,7 @@ abstract class HttpFeatureTest extends TestCase
         self::$messageFactory = new GuzzleMessageFactory();
     }
 
-    /**
-     * @return HttpClient
-     */
-    abstract protected function createClient();
+    abstract protected function createClient(): ClientInterface;
 
     /**
      * @feature Send a GET Request
@@ -39,7 +36,6 @@ abstract class HttpFeatureTest extends TestCase
 
         $response = $this->createClient()->sendRequest($request);
 
-        $this->assertInstanceOf('Psr\Http\Message\ResponseInterface', $response);
         $this->assertSame(200, $response->getStatusCode());
     }
 
@@ -58,7 +54,6 @@ abstract class HttpFeatureTest extends TestCase
 
         $response = $this->createClient()->sendRequest($request);
 
-        $this->assertInstanceOf('Psr\Http\Message\ResponseInterface', $response);
         $this->assertSame(200, $response->getStatusCode());
 
         $contents = json_decode($response->getBody()->__toString());
@@ -78,7 +73,6 @@ abstract class HttpFeatureTest extends TestCase
 
         $response = $this->createClient()->sendRequest($request);
 
-        $this->assertInstanceOf('Psr\Http\Message\ResponseInterface', $response);
         $this->assertSame(200, $response->getStatusCode());
     }
 
@@ -94,7 +88,6 @@ abstract class HttpFeatureTest extends TestCase
 
         $response = $this->createClient()->sendRequest($request);
 
-        $this->assertInstanceOf('Psr\Http\Message\ResponseInterface', $response);
         $this->assertSame(200, $response->getStatusCode());
     }
 
@@ -110,7 +103,6 @@ abstract class HttpFeatureTest extends TestCase
 
         $response = $this->createClient()->sendRequest($request);
 
-        $this->assertInstanceOf('Psr\Http\Message\ResponseInterface', $response);
         $this->assertSame(200, $response->getStatusCode());
     }
 
@@ -129,7 +121,6 @@ abstract class HttpFeatureTest extends TestCase
 
         $response = $this->createClient()->sendRequest($request);
 
-        $this->assertInstanceOf('Psr\Http\Message\ResponseInterface', $response);
         $this->assertSame(200, $response->getStatusCode());
 
         $contents = json_decode($response->getBody()->__toString());
@@ -149,7 +140,6 @@ abstract class HttpFeatureTest extends TestCase
 
         $response = $this->createClient()->sendRequest($request);
 
-        $this->assertInstanceOf('Psr\Http\Message\ResponseInterface', $response);
         $this->assertSame(200, $response->getStatusCode());
         $this->assertContains('€', $response->getBody()->__toString());
     }
@@ -166,7 +156,6 @@ abstract class HttpFeatureTest extends TestCase
 
         $response = $this->createClient()->sendRequest($request);
 
-        $this->assertInstanceOf('Psr\Http\Message\ResponseInterface', $response);
         $this->assertSame(200, $response->getStatusCode());
         $this->assertContains('gzip', $response->getBody()->__toString());
     }
@@ -183,7 +172,6 @@ abstract class HttpFeatureTest extends TestCase
 
         $response = $this->createClient()->sendRequest($request);
 
-        $this->assertInstanceOf('Psr\Http\Message\ResponseInterface', $response);
         $this->assertSame(200, $response->getStatusCode());
         $this->assertContains('deflate', $response->getBody()->__toString());
     }
@@ -200,7 +188,6 @@ abstract class HttpFeatureTest extends TestCase
 
         $response = $this->createClient()->sendRequest($request);
 
-        $this->assertInstanceOf('Psr\Http\Message\ResponseInterface', $response);
         $this->assertSame(200, $response->getStatusCode());
     }
 
@@ -216,7 +203,6 @@ abstract class HttpFeatureTest extends TestCase
 
         $response = $this->createClient()->sendRequest($request);
 
-        $this->assertInstanceOf('Psr\Http\Message\ResponseInterface', $response);
         $this->assertSame(200, $response->getStatusCode());
 
         $content = @json_decode($response->getBody()->__toString());
@@ -236,7 +222,6 @@ abstract class HttpFeatureTest extends TestCase
 
         $response = $this->createClient()->sendRequest($request);
 
-        $this->assertInstanceOf('Psr\Http\Message\ResponseInterface', $response);
         $this->assertSame(200, $response->getStatusCode());
     }
 }

--- a/src/ResultPrinter.php
+++ b/src/ResultPrinter.php
@@ -3,36 +3,19 @@
 namespace Http\Client\Tests;
 
 use PHPUnit\Framework\Test;
+use PHPUnit\TextUI\ResultPrinter as BaseResultPrinter;
 
-// If PHPUnit 6
-if (class_exists('\\PHPUnit\\TextUI\\ResultPrinter')) {
-    class ResultPrinter extends \PHPUnit\TextUI\ResultPrinter
+class ResultPrinter extends BaseResultPrinter
+{
+    use FeatureTestListener;
+
+    public function startTest(Test $test): void
     {
-        use FeatureTestListener;
-
-        public function startTest(Test $test)
-        {
-            return $this->doStartTest($test);
-        }
-
-        public function endTest(Test $test, $time)
-        {
-            return $this->doEndTest($test, $time);
-        }
+        return $this->doStartTest($test);
     }
-} else {
-    class ResultPrinter extends \PHPUnit_TextUI_ResultPrinter
+
+    public function endTest(Test $test, float $time): void
     {
-        use FeatureTestListener;
-
-        public function startTest(\PHPUnit_Framework_Test $test)
-        {
-            return $this->doStartTest($test);
-        }
-
-        public function endTest(\PHPUnit_Framework_Test $test, $time)
-        {
-            return $this->doEndTest($test, $time);
-        }
+        return $this->doEndTest($test, $time);
     }
 }


### PR DESCRIPTION
This allow library relying on psr18 only to use this tests with requiring httplug 2.0 (but it would still be compatible)

We should create a 3.x version after this is merged