### PR TITLE
Add non-symlink case to bin/http_test_server

### DIFF
--- a/bin/http_test_server
+++ b/bin/http_test_server
@@ -8,7 +8,10 @@ if [ -f "$DIR/../autoload.php" ]; then
 # Development
 elif [ -f "$DIR/../vendor/autoload.php" ]; then
     php -S 127.0.0.1:10000 -t "$DIR/../fixture"
-# Not working, e.g. windows which does not do symlinks
+# Installed as a dependency, but not accessed using the symlink (e.g. Windows)
+elif [ -f "$DIR/../composer.json" -a -f "$DIR/../fixture/server.php" ] && grep -q php-http/client-integration-tests "$DIR/../composer.json"; then
+    php -S 127.0.0.1:10000 -t "$DIR/../fixture"
+# Not working
 else
     echo "*** Can't find the fixture folder ***" >&2
     echo "Please write your own way to start a PHP web server on port 10000 for the 'fixture' directory." >&2


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | #46, #47 
| Documentation   | n/a
| License         | MIT


#### What's in this PR?

This PR hopefully adds direct support for running bin/http_test_server on Windows. Details are in #46.

I tested this PR by removing the other conditions and then running the script on Ubuntu. It worked fine. I did not actually test this on Windows, but I am confident that it _should_ work properly. In any case we are not worse off compared to the situation before.

#### Example Usage

n/a

#### Checklist

- [ ] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [x] Documentation pull request created (if not simply a bugfix)


#### To Do

- [ ] Actually test on Windows (or just hope for the best).
