### PR TITLE
Replace httpbin.org by httpbingo.org to fix postmanlabs/httpbin issues

### DIFF
--- a/src/HttpFeatureTest.php
+++ b/src/HttpFeatureTest.php
@@ -33,7 +33,7 @@ abstract class HttpFeatureTest extends TestCase
     {
         $request = self::$messageFactory->createRequest(
             'GET',
-            'http://httpbin.org/get'
+            'https://httpbingo.org/get'
         );
 
         $response = $this->createClient()->sendRequest($request);
@@ -49,7 +49,7 @@ abstract class HttpFeatureTest extends TestCase
         $testData = 'Test data';
         $request = self::$messageFactory->createRequest(
             'POST',
-            'http://httpbin.org/post',
+            'https://httpbingo.org/post',
             ['Content-Length' => strlen($testData)],
             $testData
         );
@@ -70,7 +70,7 @@ abstract class HttpFeatureTest extends TestCase
     {
         $request = self::$messageFactory->createRequest(
             'PATCH',
-            'http://httpbin.org/patch'
+            'https://httpbingo.org/patch'
         );
 
         $response = $this->createClient()->sendRequest($request);
@@ -85,7 +85,7 @@ abstract class HttpFeatureTest extends TestCase
     {
         $request = self::$messageFactory->createRequest(
             'PUT',
-            'http://httpbin.org/put'
+            'https://httpbingo.org/put'
         );
 
         $response = $this->createClient()->sendRequest($request);
@@ -100,7 +100,7 @@ abstract class HttpFeatureTest extends TestCase
     {
         $request = self::$messageFactory->createRequest(
             'DELETE',
-            'http://httpbin.org/delete'
+            'https://httpbingo.org/delete'
         );
 
         $response = $this->createClient()->sendRequest($request);
@@ -116,7 +116,7 @@ abstract class HttpFeatureTest extends TestCase
         $testData = 'Test data';
         $request = self::$messageFactory->createRequest(
             'POST',
-            'http://httpbin.org/post',
+            'https://httpbingo.org/post',
             [],
             $testData
         );
@@ -137,7 +137,7 @@ abstract class HttpFeatureTest extends TestCase
     {
         $request = self::$messageFactory->createRequest(
             'GET',
-            'http://httpbin.org/encoding/utf8'
+            'https://httpbingo.org/encoding/utf8'
         );
 
         $response = $this->createClient()->sendRequest($request);
@@ -153,7 +153,7 @@ abstract class HttpFeatureTest extends TestCase
     {
         $request = self::$messageFactory->createRequest(
             'GET',
-            'http://httpbin.org/gzip'
+            'https://httpbingo.org/gzip'
         );
 
         $response = $this->createClient()->sendRequest($request);
@@ -169,7 +169,7 @@ abstract class HttpFeatureTest extends TestCase
     {
         $request = self::$messageFactory->createRequest(
             'GET',
-            'http://httpbin.org/deflate'
+            'https://httpbingo.org/deflate'
         );
 
         $response = $this->createClient()->sendRequest($request);
@@ -185,7 +185,7 @@ abstract class HttpFeatureTest extends TestCase
     {
         $request = self::$messageFactory->createRequest(
             'GET',
-            'http://httpbin.org/redirect/1'
+            'https://httpbingo.org/redirect/1'
         );
 
         $response = $this->createClient()->sendRequest($request);
@@ -200,7 +200,7 @@ abstract class HttpFeatureTest extends TestCase
     {
         $request = self::$messageFactory->createRequest(
             'GET',
-            'http://httpbin.org/stream/1'
+            'https://httpbingo.org/stream/1'
         );
 
         $response = $this->createClient()->sendRequest($request);


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT


#### What's in this PR?

This patch replace `http://httpbin.org/` calls in HttpFeatureTest, by `https://httpbingo.org/`.


#### Why?

`httpbin.org/redirect` endpoint returns 404 resulting in tests failure.

Open issues on postmanlabs/httpbin since Jun 20, 2020 :
- https://github.com/postmanlabs/httpbin/issues/626
- https://github.com/postmanlabs/httpbin/issues/617

