### PR TITLE
Pass `''` instead of `null` to `http_build_query()`'s second parameter

### DIFF
--- a/src/HttpBaseTest.php
+++ b/src/HttpBaseTest.php
@@ -119,7 +119,7 @@ abstract class HttpBaseTest extends TestCase
     protected function getUri(array $query = [])
     {
         return !empty($query)
-            ? PHPUnitUtility::getUri().'?'.http_build_query($query, null, '&')
+            ? PHPUnitUtility::getUri().'?'.http_build_query($query, '', '&')
             : PHPUnitUtility::getUri();
     }
 
@@ -192,7 +192,7 @@ abstract class HttpBaseTest extends TestCase
     {
         return [
             null,
-            http_build_query($this->getData(), null, '&'),
+            http_build_query($this->getData(), '', '&'),
         ];
     }
 


### PR DESCRIPTION
Passing `null` will show a deprecation warning with PHP 8.1.

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | n/a
| Documentation   | n/a
| License         | MIT


#### What's in this PR?

This fixes a deprecation warning in PHP 8.1


#### Why?

> Deprecated: http_build_query(): Passing null to parameter #2 ($numeric_prefix) of type string is deprecated in /pwd/vendor/php-http/client-integration-tests/src/HttpBaseTest.php on line 195


#### Example Usage

n/a


#### Checklist

- [ ] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [ ] Documentation pull request created (if not simply a bugfix)


#### To Do

n/a
