### PR TITLE
do not specify branch name for clients to test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,14 +15,16 @@ jobs:
       max-parallel: 10
       matrix:
         batch:
-          - { suite: "curl",    php: '7.4', package: "php-http/curl-client:dev-master laminas/laminas-diactoros" }
-          - { suite: "Socket",  php: '7.4', package: "php-http/socket-client:dev-master php-http/client-common" }
-          - { suite: "Guzzle5", php: '7.1', package: "php-http/guzzle5-adapter:dev-master" }
-          - { suite: "Guzzle6", php: '7.4', package: "php-http/guzzle6-adapter:dev-master" }
-          - { suite: "Guzzle",  php: '7.4', package: "guzzlehttp/guzzle:dev-master" }
-          - { suite: "Guzzle",  php: '7.4', package: "guzzlehttp/guzzle:dev-master phpunit/phpunit:^8.5.8" }
-          - { suite: "Guzzle",  php: '7.4', package: "guzzlehttp/guzzle:dev-master phpunit/phpunit:^7.5.20" }
-          - { suite: "Buzz",    php: '7.4', package: "kriswallsmith/buzz:dev-master" }
+          - { suite: "curl",    php: '7.4', package: "php-http/curl-client laminas/laminas-diactoros php-http/message-factory" }
+          - { suite: "Socket",  php: '7.4', package: "php-http/socket-client php-http/client-common php-http/message-factory" }
+          - { suite: "Guzzle5", php: '7.4', package: "php-http/guzzle5-adapter php-http/message-factory" }
+          - { suite: "Guzzle6", php: '7.4', package: "php-http/guzzle6-adapter php-http/message-factory" }
+          - { suite: "Guzzle",  php: '7.4', package: "guzzlehttp/guzzle php-http/message-factory" }
+          - { suite: "Guzzle",  php: '8.3', package: "guzzlehttp/guzzle php-http/message-factory" }
+          - { suite: "Guzzle",  php: '7.4', package: "guzzlehttp/guzzle phpunit/phpunit:^8.5.8 php-http/message-factory" }
+          - { suite: "Guzzle",  php: '7.4', package: "guzzlehttp/guzzle phpunit/phpunit:^7.5.20 php-http/message-factory" }
+          - { suite: "Buzz",    php: '7.4', package: "kriswallsmith/buzz psr/log php-http/message-factory" }
+          - { suite: "Buzz",    php: '8.3', package: "kriswallsmith/buzz psr/log php-http/message-factory" }
 
     steps:
       - name: Set up PHP

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,6 @@ jobs:
         batch:
           - { suite: "curl",    php: '7.4', package: "php-http/curl-client laminas/laminas-diactoros php-http/message-factory" }
           - { suite: "Socket",  php: '7.4', package: "php-http/socket-client php-http/client-common php-http/message-factory" }
-          - { suite: "Guzzle5", php: '7.4', package: "php-http/guzzle5-adapter php-http/message-factory" }
-          - { suite: "Guzzle6", php: '7.4', package: "php-http/guzzle6-adapter php-http/message-factory" }
           - { suite: "Guzzle",  php: '7.4', package: "guzzlehttp/guzzle php-http/message-factory" }
           - { suite: "Guzzle",  php: '8.3', package: "guzzlehttp/guzzle php-http/message-factory" }
           - { suite: "Guzzle",  php: '7.4', package: "guzzlehttp/guzzle phpunit/phpunit:^8.5.8 php-http/message-factory" }

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 Via Composer
 
 ```bash
-$ composer require php-http/client-integration-tests
+composer require php-http/client-integration-tests
 ```
 
 
@@ -26,13 +26,13 @@ This package should not be used on its own. It provides integration tests for HT
 Start the HTTP Test server:
 
 ```bash
-$ vendor/bin/http_test_server
+vendor/bin/http_test_server
 ```
 
 Install an adapter.
 
 ```bash
-$ composer require php-http/curl-client:dev-master laminas/laminas-diactoros
+composer require php-http/curl-client laminas/laminas-diactoros
 ```
 
 Run the tests.

--- a/composer.json
+++ b/composer.json
@@ -15,10 +15,11 @@
         }
     ],
     "require": {
-        "php": "^7.1 || ^8.0",
-        "phpunit/phpunit": "^7.5.20 || ^8.5.8 || ^9.3.11",
+        "php": "^7.4 || ^8.0",
+        "phpunit/phpunit": "^9.6.17",
         "php-http/message": "^1.0 || ^2.0",
-        "guzzlehttp/psr7": "^1.7 || ^2.0",
+        "php-http/message-factory": "^1.0",
+        "guzzlehttp/psr7": "^1.9 || ^2.0",
         "th3n3rd/cartesian-product": "^0.3"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
         "php-http/httplug": "To test async client"
     },
     "require-dev": {
-        "php-http/httplug": "^2.0"
+        "php-http/httplug": "^2.0",
+        "nyholm/psr7": "^1.8@dev"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
#### What's in this PR?

Do not specify the branch names of clients to install.

#### Why?

All clients renamed the branch to main or, more often, switched to semantic branch naming where the default branch is 2.x or 3.x etc. 

It makes more sense for this repository to test the latest released version of the clients rather than dev versions. The clients can use this repository if they want to look at the test suite during development.