### PR TITLE
Revert to httpbin org

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.1] - 2024-xx-xx
+
+- Switched to `httpbin.org` for tests
+
 ## [3.1.0] - 2024-03-05
 
 - Removed builds for abandoned guzzle5 and guzzle6 adapters

--- a/src/HttpFeatureTest.php
+++ b/src/HttpFeatureTest.php
@@ -33,7 +33,7 @@ abstract class HttpFeatureTest extends TestCase
     {
         $request = self::$messageFactory->createRequest(
             'GET',
-            'https://httpbingo.org/get'
+            'http://httpbin.org/get'
         );
 
         $response = $this->createClient()->sendRequest($request);
@@ -49,7 +49,7 @@ abstract class HttpFeatureTest extends TestCase
         $testData = 'Test data';
         $request = self::$messageFactory->createRequest(
             'POST',
-            'https://httpbingo.org/post',
+            'http://httpbin.org/post',
             ['Content-Length' => strlen($testData)],
             $testData
         );
@@ -70,7 +70,7 @@ abstract class HttpFeatureTest extends TestCase
     {
         $request = self::$messageFactory->createRequest(
             'PATCH',
-            'https://httpbingo.org/patch'
+            'http://httpbin.org/patch'
         );
 
         $response = $this->createClient()->sendRequest($request);
@@ -85,7 +85,7 @@ abstract class HttpFeatureTest extends TestCase
     {
         $request = self::$messageFactory->createRequest(
             'PUT',
-            'https://httpbingo.org/put'
+            'http://httpbin.org/put'
         );
 
         $response = $this->createClient()->sendRequest($request);
@@ -100,7 +100,7 @@ abstract class HttpFeatureTest extends TestCase
     {
         $request = self::$messageFactory->createRequest(
             'DELETE',
-            'https://httpbingo.org/delete'
+            'http://httpbin.org/delete'
         );
 
         $response = $this->createClient()->sendRequest($request);
@@ -116,7 +116,7 @@ abstract class HttpFeatureTest extends TestCase
         $testData = 'Test data';
         $request = self::$messageFactory->createRequest(
             'POST',
-            'https://httpbingo.org/post',
+            'http://httpbin.org/post',
             [],
             $testData
         );
@@ -137,7 +137,7 @@ abstract class HttpFeatureTest extends TestCase
     {
         $request = self::$messageFactory->createRequest(
             'GET',
-            'https://httpbingo.org/encoding/utf8'
+            'http://httpbin.org/encoding/utf8'
         );
 
         $response = $this->createClient()->sendRequest($request);
@@ -153,7 +153,7 @@ abstract class HttpFeatureTest extends TestCase
     {
         $request = self::$messageFactory->createRequest(
             'GET',
-            'https://httpbingo.org/gzip'
+            'http://httpbin.org/gzip'
         );
 
         $response = $this->createClient()->sendRequest($request);
@@ -169,7 +169,7 @@ abstract class HttpFeatureTest extends TestCase
     {
         $request = self::$messageFactory->createRequest(
             'GET',
-            'https://httpbingo.org/deflate'
+            'http://httpbin.org/deflate'
         );
 
         $response = $this->createClient()->sendRequest($request);
@@ -185,7 +185,7 @@ abstract class HttpFeatureTest extends TestCase
     {
         $request = self::$messageFactory->createRequest(
             'GET',
-            'https://httpbingo.org/redirect/1'
+            'http://httpbin.org/redirect/1'
         );
 
         $response = $this->createClient()->sendRequest($request);
@@ -200,7 +200,7 @@ abstract class HttpFeatureTest extends TestCase
     {
         $request = self::$messageFactory->createRequest(
             'GET',
-            'https://httpbingo.org/stream/1'
+            'http://httpbin.org/stream/1'
         );
 
         $response = $this->createClient()->sendRequest($request);

--- a/src/HttpFeatureTest.php
+++ b/src/HttpFeatureTest.php
@@ -33,7 +33,7 @@ abstract class HttpFeatureTest extends TestCase
     {
         $request = self::$messageFactory->createRequest(
             'GET',
-            'http://httpbin.org/get'
+            'https://httpbin.org/get'
         );
 
         $response = $this->createClient()->sendRequest($request);
@@ -49,7 +49,7 @@ abstract class HttpFeatureTest extends TestCase
         $testData = 'Test data';
         $request = self::$messageFactory->createRequest(
             'POST',
-            'http://httpbin.org/post',
+            'https://httpbin.org/post',
             ['Content-Length' => strlen($testData)],
             $testData
         );
@@ -70,7 +70,7 @@ abstract class HttpFeatureTest extends TestCase
     {
         $request = self::$messageFactory->createRequest(
             'PATCH',
-            'http://httpbin.org/patch'
+            'https://httpbin.org/patch'
         );
 
         $response = $this->createClient()->sendRequest($request);
@@ -85,7 +85,7 @@ abstract class HttpFeatureTest extends TestCase
     {
         $request = self::$messageFactory->createRequest(
             'PUT',
-            'http://httpbin.org/put'
+            'https://httpbin.org/put'
         );
 
         $response = $this->createClient()->sendRequest($request);
@@ -100,7 +100,7 @@ abstract class HttpFeatureTest extends TestCase
     {
         $request = self::$messageFactory->createRequest(
             'DELETE',
-            'http://httpbin.org/delete'
+            'https://httpbin.org/delete'
         );
 
         $response = $this->createClient()->sendRequest($request);
@@ -116,7 +116,7 @@ abstract class HttpFeatureTest extends TestCase
         $testData = 'Test data';
         $request = self::$messageFactory->createRequest(
             'POST',
-            'http://httpbin.org/post',
+            'https://httpbin.org/post',
             [],
             $testData
         );
@@ -137,7 +137,7 @@ abstract class HttpFeatureTest extends TestCase
     {
         $request = self::$messageFactory->createRequest(
             'GET',
-            'http://httpbin.org/encoding/utf8'
+            'https://httpbin.org/encoding/utf8'
         );
 
         $response = $this->createClient()->sendRequest($request);
@@ -153,7 +153,7 @@ abstract class HttpFeatureTest extends TestCase
     {
         $request = self::$messageFactory->createRequest(
             'GET',
-            'http://httpbin.org/gzip'
+            'https://httpbin.org/gzip'
         );
 
         $response = $this->createClient()->sendRequest($request);
@@ -169,7 +169,7 @@ abstract class HttpFeatureTest extends TestCase
     {
         $request = self::$messageFactory->createRequest(
             'GET',
-            'http://httpbin.org/deflate'
+            'https://httpbin.org/deflate'
         );
 
         $response = $this->createClient()->sendRequest($request);
@@ -185,7 +185,7 @@ abstract class HttpFeatureTest extends TestCase
     {
         $request = self::$messageFactory->createRequest(
             'GET',
-            'http://httpbin.org/redirect/1'
+            'https://httpbin.org/redirect/1'
         );
 
         $response = $this->createClient()->sendRequest($request);
@@ -200,7 +200,7 @@ abstract class HttpFeatureTest extends TestCase
     {
         $request = self::$messageFactory->createRequest(
             'GET',
-            'http://httpbin.org/stream/1'
+            'https://httpbin.org/stream/1'
         );
 
         $response = $this->createClient()->sendRequest($request);


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | See https://github.com/php-http/socket-client/pull/72#issuecomment-2166882157
| Documentation   | 
| License         | MIT


#### What's in this PR?

Switched from `https://httpbingo.org` in favor of `https://httpbin.org` (revert of https://github.com/php-http/client-integration-tests/pull/56 + switching to https)

The original problem with the upstream service was resolved: https://github.com/postmanlabs/httpbin/issues/617

#### Why?

Service `https://httpbingo.org` returns `402 Payment Required` status code for requests with no user agent (use-case of `php-http/php-socket-client`).

Using this service with such side effects makes it harder to know what is wrong with some specific HTTP client adapter when tests failed just in one day (when upstream changed its rules).

Let's do it if we can switch to another service without such a strange behavior.

```
$ curl --request GET 'https://httpbingo.org/get' -H 'User-Agent:' -i
HTTP/2 402 
date: Wed, 07 Aug 2024 21:08:32 GMT
content-length: 0
server: Fly/9fe23f3e1 (2024-07-31)
via: 2 fly.io
fly-request-id: 01J4QAR1ZXN5JDQ4YBCC7R12ZZ-ams
```


#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [ ] Documentation pull request created (if not simply a bugfix)

